### PR TITLE
add in non-blocking functionality to the context manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-  - DATABASE_URL=postgres://postgres@localhost/tusk
+  - DATABASE_URL=postgres://postgres@localhost/tusk:5432
 python:
   - 2.7
 install: pip install -q tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   - DATABASE_URL=postgres://postgres@localhost/tusk
 python:
   - 2.7
-install: pip install -q --use-mirrors tox
+install: pip install -q tox
 before_script:
   - psql -c 'create database tusk;' -U postgres
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-  - DATABASE_URL=postgres://postgres@localhost/tusk:5432
+  - DATABASE_URL=postgres://postgres@localhost:5432/tusk
 python:
   - 2.7
 install: pip install -q tox

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        'psycopg2>=2.4.2',
+        'psycopg2>=2.7',
     ],
     include_package_data=True,
     classifiers=[

--- a/tests/test_tusk.py
+++ b/tests/test_tusk.py
@@ -9,8 +9,8 @@ from tusk import Lock
 class TuskTest(TestCase):
     def setUp(self):
         dsn = os.environ.get("DATABASE_URL")
-        self.former = Lock("tusk", dsn or "postgres://localhost/tusk")
-        self.latter = Lock("tusk", dsn or "postgres://localhost/tusk")
+        self.former = Lock("tusk", dsn or "postgres://localhost/tusk:5432")
+        self.latter = Lock("tusk", dsn or "postgres://localhost/tusk:5432")
 
     def test_acquire_release(self):
         self.former.acquire()

--- a/tests/test_tusk.py
+++ b/tests/test_tusk.py
@@ -9,8 +9,8 @@ from tusk import Lock
 class TuskTest(TestCase):
     def setUp(self):
         dsn = os.environ.get("DATABASE_URL")
-        self.former = Lock("tusk", dsn or "postgres://localhost/tusk:5432")
-        self.latter = Lock("tusk", dsn or "postgres://localhost/tusk:5432")
+        self.former = Lock("tusk", dsn or "postgres://localhost:5432/tusk")
+        self.latter = Lock("tusk", dsn or "postgres://localhost:5432/tusk")
 
     def test_acquire_release(self):
         self.former.acquire()

--- a/tusk/__init__.py
+++ b/tusk/__init__.py
@@ -20,10 +20,7 @@ class Lock(object):
         dsn = dsn or os.environ.get('DATABASE_URL')
         if dsn is None:
             raise ValueError("You must specify a DSN.")
-        params = urlparse(dsn)
-        self.conn = psycopg2.connect(database=params.path[1:], user=params.username,
-                                     password=params.password, host=params.hostname,
-                                     port=params.port)
+        self.conn = psycopg2.connect(dsn=dsn)
         self.conn.autocommit = True
         self.key = self._key(name)
         self.blocking = blocking


### PR DESCRIPTION
Hi cyberdelia,

Noticed this codebase is quite old, but it's simple, easy to read, and it works so I figured I'd use it. Just noticed that if I want my processes to explicitly raise errors and not hang, I won't be able to use the context manager. I figured it was a simple enough fix, and this is essentially what I do in my codebase with a subclass. My pull request essentially adds the default blocking behavior as a class attribute, so that the context manager can handle the case where you don't want it to hang, and instead get an explicit error. 

You'd use it like you originally do in your readme for the blocking connection:

```python
l = Lock("inspector", "postgres://localhost/noclue")
l.acquire(blocking=True)
l.release()
with l:
    process()
```

But then you can also instantiate the class with the blocking attribute

```python
l = Lock("inspector", "postgres://localhost/noclue", blocking=False)
with l:
    process()
```
While the above is running, another process tries to run

```python
l2 = Lock("inspector", "postgres://localhost/noclue", blocking=False)
with l2: # fails here with a RuntimeError
    process()
```